### PR TITLE
Add a breaking test and fix it

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "babel src -d lib",
-    "test": "npm run build && istanbul cover jasmine",
+    "test": "npm run build && NODE_CONFIG_DIR=./spec/config istanbul cover jasmine",
     "lint": "eslint src/** spec/**",
     "prepublish": "npm run build",
     "pretest": "npm run lint"
@@ -32,6 +32,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-0": "^6.16.0",
     "codecov": "^1.0.1",
+    "config": "^1.24.0",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "2.2.0",

--- a/spec/config/test.js
+++ b/spec/config/test.js
@@ -1,0 +1,6 @@
+const FirehoseLoggerAdapter = require('../../lib/index.js').FirehoseLoggerAdapter;
+const raw = require('config/raw').raw;
+
+module.exports = {
+  logger: raw(new FirehoseLoggerAdapter({ streamName: 'test' })),
+};

--- a/spec/firehoseLoggerAdapterSpec.js
+++ b/spec/firehoseLoggerAdapterSpec.js
@@ -1,4 +1,5 @@
 const FirehoseLoggerAdapter = require('../lib/index.js').FirehoseLoggerAdapter;
+const config = require('config');
 
 // If you want to actually send a test log, then set NODE_ENV to something
 // other than 'test'.  See spec/helpers
@@ -20,5 +21,9 @@ describe('FirehoseLoggerAdapter configuration tests', () => {
     process.env.FIREHOSE_LOGGER_STREAM_NAME = 'test-stream';
     expect(() => new FirehoseLoggerAdapter()).not.toThrow();
     delete process.env.FIREHOSE_LOGGER_STREAM_NAME;
+  });
+
+  it('should load config', () => {
+    expect(config.get('logger')).not.toBe(null);
   });
 });


### PR DESCRIPTION
Including this adapter in config files started to break with an update
to an underlying dependency.
- add a unit test that breaks config
- use config's raw function to fix the breaking test