### PR TITLE
Altered How Level Parameter is read

### DIFF
--- a/spec/config/test.js
+++ b/spec/config/test.js
@@ -1,3 +1,3 @@
 module.exports = {
-  loggerOptions: { streamName: 'test' },
+  loggerOptions: { streamName: 'test', level: 'verbose' },
 };

--- a/spec/firehoseLoggerAdapterSpec.js
+++ b/spec/firehoseLoggerAdapterSpec.js
@@ -23,6 +23,13 @@ describe('FirehoseLoggerAdapter configuration tests', () => {
     delete process.env.FIREHOSE_LOGGER_STREAM_NAME;
   });
 
+  it('can configure with passed in level from config', () => {
+    const options = config.get('loggerOptions');
+    const logger = new FirehoseLoggerAdapter(options);
+    const level = logger.options.level;
+    expect(level).toBe('verbose');
+  });
+
   it('should be able to use immutable config', () => {
     const options = config.get('loggerOptions');
     const logger = new FirehoseLoggerAdapter(options);

--- a/src/FirehoseLoggerAdapter.js
+++ b/src/FirehoseLoggerAdapter.js
@@ -31,7 +31,7 @@ export class FirehoseLoggerAdapter extends WinstonLoggerAdapter {
   }
 
   static fromEnvironmentOrDefault(args, key, env, defaultValue) {
-    const val = (Array.isArray(args) && args[key]) ||
+    const val = (args && args[key]) ||
       process.env[env] ||
       defaultValue;
 
@@ -46,13 +46,11 @@ export class FirehoseLoggerAdapter extends WinstonLoggerAdapter {
       streamNameOrOptions,
       'streamName',
       'FIREHOSE_LOGGER_STREAM_NAME');
-
+    options.level = FirehoseLoggerAdapter.fromEnvironmentOrDefault(streamNameOrOptions, 'level', 'FIREHOSE_LOGGER_LEVEL', '');
 
     const firehoseOptions = {};
     firehoseOptions.region = FirehoseLoggerAdapter.fromEnvironmentOrDefault(
       firehoseOptions, 'region', 'FIREHOSE_LOGGER_REGION', DEFAULT_REGION);
-    firehoseOptions.level = FirehoseLoggerAdapter.fromEnvironmentOrDefault(
-      firehoseOptions, 'level', 'FIREHOSE_LOGGER_LEVEL', '');
 
 
     options.firehoseOptions = {};


### PR DESCRIPTION
As discussed in the Parse-Server repo, I had trouble getting the verbose logs to appear in my cluster. After debugging for a while, I found the issue.

Currently, the level parameter was getting passed in to the WinstonFirehose constructor within the firehoseOptions object. WinstonFirehose wouldn't check that object so the level would default to info.

I changed it so level doesn't get added into that object and therefore, does not default to info.